### PR TITLE
fix: incorrect mlspp namespace

### DIFF
--- a/cpp/common.h
+++ b/cpp/common.h
@@ -7,10 +7,11 @@
 #include <string>
 #include <variant>
 #include <vector>
+#include <namespace.h>
 
 #include "version.h"
 
-namespace mlspp::bytes_ns {
+namespace MLS_NAMESPACE::bytes_ns {
 struct bytes;
 };
 
@@ -20,7 +21,7 @@ namespace dave {
 using UnencryptedFrameHeaderSize = uint16_t;
 using TruncatedSyncNonce = uint32_t;
 using MagicMarker = uint16_t;
-using EncryptionKey = ::mlspp::bytes_ns::bytes;
+using EncryptionKey = ::MLS_NAMESPACE::bytes_ns::bytes;
 using TransitionId = uint16_t;
 using SupplementalBytesSize = uint8_t;
 

--- a/cpp/mls_key_ratchet.cpp
+++ b/cpp/mls_key_ratchet.cpp
@@ -7,7 +7,7 @@
 namespace discord {
 namespace dave {
 
-MlsKeyRatchet::MlsKeyRatchet(::mlspp::CipherSuite suite, bytes baseSecret) noexcept
+MlsKeyRatchet::MlsKeyRatchet(::MLS_NAMESPACE::CipherSuite suite, bytes baseSecret) noexcept
   : hashRatchet_(suite, std::move(baseSecret))
 {
 }

--- a/cpp/mls_key_ratchet.h
+++ b/cpp/mls_key_ratchet.h
@@ -9,14 +9,14 @@ namespace dave {
 
 class MlsKeyRatchet : public IKeyRatchet {
 public:
-    MlsKeyRatchet(::mlspp::CipherSuite suite, bytes baseSecret) noexcept;
+    MlsKeyRatchet(::MLS_NAMESPACE::CipherSuite suite, bytes baseSecret) noexcept;
     ~MlsKeyRatchet() noexcept override;
 
     EncryptionKey GetKey(KeyGeneration generation) noexcept override;
     void DeleteKey(KeyGeneration generation) noexcept override;
 
 private:
-    ::mlspp::HashRatchet hashRatchet_;
+    ::MLS_NAMESPACE::HashRatchet hashRatchet_;
 };
 
 } // namespace dave


### PR DESCRIPTION
Hey folks!

I was setting up your codebase locally, and it seems your mlspp related code is using an incorrect (outdated?) namespace.
The library exposes a MLS_NAMESPACE macro which I am using here to ensure the correct namespace for said library.

This issue probably arises from you guys using a specific, older version of mlspp which used the `mlspp` namespace over the new `mls` namespace. Your readme.md does not specify dependency versions, so I figured I'd address this issue. You might need to update mlspp on your end.

There were more issues I found in the codebase I will be going over gradually, such as missing header files.
To elaborate on the above, there are certain functions you're using which are only included because other std headers happen to include them, but unfortunately that is implementation-specific and on my end the code did not compile because of it.
More PRs to come, including one addressing this.

Thanks,
Tuur