### PR TITLE
fix: sys/stat.h is required on some unix platforms

### DIFF
--- a/cpp/src/dave/mls/detail/persisted_key_pair_generic.cpp
+++ b/cpp/src/dave/mls/detail/persisted_key_pair_generic.cpp
@@ -12,6 +12,7 @@
 #include <io.h>
 #else
 #include <unistd.h>
+#include <sys/stat.h>
 #endif
 #include <fcntl.h>
 


### PR DESCRIPTION
`sys/stat.h` is needed to be explicitly included on some unix platforms (notably FreeBSD) due to it being the palce where `S_IRUSR` and `S_IWUSR` are defined.

Backported from https://github.com/brainboxdotcc/DPP/issues/1323