### PR TITLE
Use nested namespace declarations

### DIFF
--- a/cpp/includes/array_view.h
+++ b/cpp/includes/array_view.h
@@ -4,8 +4,7 @@
 #include <cstddef>
 #include <vector>
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 template <typename T>
 class ArrayView {
@@ -40,5 +39,4 @@ inline ArrayView<T> MakeArrayView(std::vector<T>& data)
     return ArrayView<T>(data.data(), data.size());
 }
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/includes/dave_interfaces.h
+++ b/cpp/includes/dave_interfaces.h
@@ -22,8 +22,7 @@ struct SignaturePrivateKey;
 } // namespace mlspp
 
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 using EncryptorStats = DAVEEncryptorStats;
 using DecryptorStats = DAVEDecryptorStats;
@@ -211,5 +210,4 @@ static_assert(DAVE_LOGGING_SEVERITY_WARNING == static_cast<int>(LoggingSeverity:
 static_assert(DAVE_LOGGING_SEVERITY_ERROR == static_cast<int>(LoggingSeverity::LS_ERROR));
 static_assert(DAVE_LOGGING_SEVERITY_NONE == static_cast<int>(LoggingSeverity::LS_NONE));
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/bindings_wasm.cpp
+++ b/cpp/src/dave/bindings_wasm.cpp
@@ -21,8 +21,7 @@
 
 using namespace emscripten;
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 val ToOwnedTypedArray(const uint8_t* data, size_t size)
 {
@@ -314,8 +313,7 @@ private:
     std::unique_ptr<Decryptor> decryptor_;
 };
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave
 
 EMSCRIPTEN_BINDINGS(dave)
 {

--- a/cpp/src/dave/boringssl_cryptor.cpp
+++ b/cpp/src/dave/boringssl_cryptor.cpp
@@ -7,8 +7,7 @@
 #include "dave/common.h"
 #include "dave/logger.h"
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 void PrintSSLErrors()
 {
@@ -100,5 +99,4 @@ bool BoringSSLCryptor::Decrypt(ArrayView<uint8_t> plaintextBufferOut,
     return decryptResult == 1;
 }
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/boringssl_cryptor.h
+++ b/cpp/src/dave/boringssl_cryptor.h
@@ -4,8 +4,7 @@
 
 #include "dave/cryptor.h"
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 class BoringSSLCryptor : public ICryptor {
 public:
@@ -29,5 +28,4 @@ private:
     EVP_AEAD_CTX cipherCtx_;
 };
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/codec_utils.cpp
+++ b/cpp/src/dave/codec_utils.cpp
@@ -8,9 +8,7 @@
 #include "logger.h"
 #include "utils/leb128.h"
 
-namespace discord {
-namespace dave {
-namespace codec_utils {
+namespace discord::dave::codec_utils {
 
 UnencryptedFrameHeaderSize BytesCoveringH264PPS(const uint8_t* payload,
                                                 const uint64_t sizeRemaining)
@@ -439,6 +437,4 @@ bool ValidateEncryptedFrame(OutboundFrameProcessor& processor, ArrayView<uint8_t
     return true;
 }
 
-} // namespace codec_utils
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave::codec_utils

--- a/cpp/src/dave/codec_utils.h
+++ b/cpp/src/dave/codec_utils.h
@@ -5,9 +5,7 @@
 #include "common.h"
 #include "dave/frame_processors.h"
 
-namespace discord {
-namespace dave {
-namespace codec_utils {
+namespace discord::dave::codec_utils {
 
 bool ProcessFrameOpus(OutboundFrameProcessor& processor, ArrayView<const uint8_t> frame);
 bool ProcessFrameVp8(OutboundFrameProcessor& processor, ArrayView<const uint8_t> frame);
@@ -18,6 +16,4 @@ bool ProcessFrameAv1(OutboundFrameProcessor& processor, ArrayView<const uint8_t>
 
 bool ValidateEncryptedFrame(OutboundFrameProcessor& processor, ArrayView<uint8_t> frame);
 
-} // namespace codec_utils
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave::codec_utils

--- a/cpp/src/dave/common.h
+++ b/cpp/src/dave/common.h
@@ -10,8 +10,7 @@
 
 #include "version.h"
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 using UnencryptedFrameHeaderSize = uint16_t;
 using TruncatedSyncNonce = uint32_t;
@@ -64,5 +63,4 @@ inline std::optional<T> GetOptional(V&& variant)
     }
 }
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/cryptor.cpp
+++ b/cpp/src/dave/cryptor.cpp
@@ -6,8 +6,7 @@
 #include "openssl_cryptor.h"
 #endif
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 std::unique_ptr<ICryptor> CreateCryptor(const EncryptionKey& encryptionKey)
 {
@@ -20,5 +19,4 @@ std::unique_ptr<ICryptor> CreateCryptor(const EncryptionKey& encryptionKey)
     return cryptor->IsValid() ? std::move(cryptor) : nullptr;
 }
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/cryptor.h
+++ b/cpp/src/dave/cryptor.h
@@ -6,8 +6,7 @@
 
 #include "dave_interfaces.h"
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 class ICryptor {
 public:
@@ -27,5 +26,4 @@ public:
 
 std::unique_ptr<ICryptor> CreateCryptor(const EncryptionKey& encryptionKey);
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/cryptor_manager.cpp
+++ b/cpp/src/dave/cryptor_manager.cpp
@@ -8,8 +8,7 @@
 
 using namespace std::chrono_literals;
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 KeyGeneration ComputeWrappedGeneration(KeyGeneration oldest, KeyGeneration generation)
 {
@@ -179,5 +178,4 @@ void CryptorManager::CleanupExpiredCryptors()
     }
 }
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/cryptor_manager.h
+++ b/cpp/src/dave/cryptor_manager.h
@@ -9,8 +9,7 @@
 #include "dave/common.h"
 #include "utils/clock.h"
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 KeyGeneration ComputeWrappedGeneration(KeyGeneration oldest, KeyGeneration generation);
 
@@ -54,5 +53,4 @@ private:
     std::deque<BigNonce> missingNonces_;
 };
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/decryptor.cpp
+++ b/cpp/src/dave/decryptor.cpp
@@ -11,8 +11,7 @@
 
 using namespace std::chrono_literals;
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 constexpr auto kStatsInterval = 10s;
 
@@ -239,5 +238,4 @@ void Decryptor::ReturnFrameProcessor(std::unique_ptr<InboundFrameProcessor> fram
     frameProcessors_.push_back(std::move(frameProcessor));
 }
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/decryptor.h
+++ b/cpp/src/dave/decryptor.h
@@ -17,8 +17,7 @@
 #include "frame_processors.h"
 #include "utils/clock.h"
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 class IKeyRatchet;
 
@@ -71,5 +70,4 @@ private:
     std::array<DecryptorStats, 2> stats_;
 };
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/encryptor.cpp
+++ b/cpp/src/dave/encryptor.cpp
@@ -16,8 +16,7 @@
 
 using namespace std::chrono_literals;
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 constexpr auto kStatsInterval = 10s;
 
@@ -308,5 +307,4 @@ void Encryptor::UpdateCurrentProtocolVersion(ProtocolVersion version)
     }
 }
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/encryptor.h
+++ b/cpp/src/dave/encryptor.h
@@ -16,8 +16,7 @@
 #include "dave/frame_processors.h"
 #include "dave/version.h"
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 class Encryptor final : public IEncryptor {
 public:
@@ -82,5 +81,4 @@ private:
     ProtocolVersion currentProtocolVersion_{MaxSupportedProtocolVersion()};
 };
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/frame_processors.cpp
+++ b/cpp/src/dave/frame_processors.cpp
@@ -15,8 +15,7 @@
 #include <intrin.h>
 #endif
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 std::pair<bool, size_t> OverflowAdd(size_t a, size_t b)
 {
@@ -398,5 +397,4 @@ void OutboundFrameProcessor::AddEncryptedBytes(const uint8_t* bytes, size_t size
     frameIndex_ += size;
 }
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/frame_processors.h
+++ b/cpp/src/dave/frame_processors.h
@@ -10,8 +10,7 @@
 #include "common.h"
 #include "dave_interfaces.h"
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 struct Range {
     size_t offset;
@@ -87,5 +86,4 @@ private:
     Ranges unencryptedRanges_;
 };
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/key_ratchet.h
+++ b/cpp/src/dave/key_ratchet.h
@@ -4,8 +4,6 @@
 
 #include "common.h"
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/logger.cpp
+++ b/cpp/src/dave/logger.cpp
@@ -4,8 +4,7 @@
 #include <cstring>
 #include <iostream>
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 std::atomic<LogSink> gLogSink = nullptr;
 
@@ -51,5 +50,4 @@ LogStreamer::~LogStreamer()
     }
 }
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/logger.h
+++ b/cpp/src/dave/logger.h
@@ -8,8 +8,7 @@
 #define DISCORD_LOG_FILE_LINE(sev, file, line) ::discord::dave::LogStreamer(sev, file, line)
 #define DISCORD_LOG(sev) DISCORD_LOG_FILE_LINE(::discord::dave::sev, __FILE__, __LINE__)
 #endif
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 using LogSink = void (*)(LoggingSeverity severity,
                          const char* file,
@@ -36,5 +35,4 @@ private:
     std::ostringstream stream_;
 };
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/mls/detail/persisted_key_pair.h
+++ b/cpp/src/dave/mls/detail/persisted_key_pair.h
@@ -7,10 +7,7 @@
 
 #include "dave/mls/persisted_key_pair.h"
 
-namespace discord {
-namespace dave {
-namespace mls {
-namespace detail {
+namespace discord::dave::mls::detail {
 
 std::shared_ptr<::mlspp::SignaturePrivateKey> GetNativePersistedKeyPair(KeyPairContextType ctx,
                                                                         const std::string& keyID,
@@ -24,7 +21,4 @@ std::shared_ptr<::mlspp::SignaturePrivateKey> GetGenericPersistedKeyPair(
 bool DeleteNativePersistedKeyPair(KeyPairContextType ctx, const std::string& keyID);
 bool DeleteGenericPersistedKeyPair(KeyPairContextType ctx, const std::string& keyID);
 
-} // namespace detail
-} // namespace mls
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave::mls::detail

--- a/cpp/src/dave/mls/parameters.cpp
+++ b/cpp/src/dave/mls/parameters.cpp
@@ -1,8 +1,6 @@
 #include "parameters.h"
 
-namespace discord {
-namespace dave {
-namespace mls {
+namespace discord::dave::mls {
 
 ::mlspp::CipherSuite::ID CiphersuiteIDForProtocolVersion(
   [[maybe_unused]] ProtocolVersion version) noexcept
@@ -55,6 +53,4 @@ namespace mls {
     return extensionList;
 }
 
-} // namespace mls
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave::mls

--- a/cpp/src/dave/mls/parameters.h
+++ b/cpp/src/dave/mls/parameters.h
@@ -6,9 +6,7 @@
 
 #include "dave/version.h"
 
-namespace discord {
-namespace dave {
-namespace mls {
+namespace discord::dave::mls {
 
 ::mlspp::CipherSuite::ID CiphersuiteIDForProtocolVersion(ProtocolVersion version) noexcept;
 ::mlspp::CipherSuite CiphersuiteForProtocolVersion(ProtocolVersion version) noexcept;
@@ -20,6 +18,4 @@ namespace mls {
   ProtocolVersion version,
   const ::mlspp::ExternalSender& externalSender) noexcept;
 
-} // namespace mls
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave::mls

--- a/cpp/src/dave/mls/persisted_key_pair.cpp
+++ b/cpp/src/dave/mls/persisted_key_pair.cpp
@@ -25,9 +25,7 @@ static std::string MakeKeyID(const std::string& sessionID, ::mlspp::CipherSuite 
 static std::mutex mtx;
 static std::map<std::string, std::shared_ptr<::mlspp::SignaturePrivateKey>> map;
 
-namespace discord {
-namespace dave {
-namespace mls {
+namespace discord::dave::mls {
 
 static std::shared_ptr<::mlspp::SignaturePrivateKey> GetPersistedKeyPair(
   [[maybe_unused]] KeyPairContextType ctx,
@@ -110,6 +108,4 @@ bool DeletePersistedKeyPair([[maybe_unused]] KeyPairContextType ctx,
     return native || generic;
 }
 
-} // namespace mls
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave::mls

--- a/cpp/src/dave/mls/persisted_key_pair.h
+++ b/cpp/src/dave/mls/persisted_key_pair.h
@@ -16,9 +16,7 @@ namespace mlspp {
 struct SignaturePrivateKey;
 };
 
-namespace discord {
-namespace dave {
-namespace mls {
+namespace discord::dave::mls {
 
 std::shared_ptr<::mlspp::SignaturePrivateKey> GetPersistedKeyPair(KeyPairContextType ctx,
                                                                   const std::string& sessionID,
@@ -39,6 +37,4 @@ bool DeletePersistedKeyPair(KeyPairContextType ctx,
 
 constexpr unsigned KeyVersion = 1;
 
-} // namespace mls
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave::mls

--- a/cpp/src/dave/mls/persisted_key_pair_null.cpp
+++ b/cpp/src/dave/mls/persisted_key_pair_null.cpp
@@ -1,8 +1,6 @@
 #include "persisted_key_pair.h"
 
-namespace discord {
-namespace dave {
-namespace mls {
+namespace discord::dave::mls {
 
 std::shared_ptr<::mlspp::SignaturePrivateKey> GetPersistedKeyPair(
   [[maybe_unused]] KeyPairContextType,
@@ -19,6 +17,4 @@ bool DeletePersistedKeyPair([[maybe_unused]] KeyPairContextType,
     return false;
 }
 
-} // namespace mls
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave::mls

--- a/cpp/src/dave/mls/session.cpp
+++ b/cpp/src/dave/mls/session.cpp
@@ -25,9 +25,7 @@
         onMLSFailureCallback_(__FUNCTION__, reason); \
     }
 
-namespace discord {
-namespace dave {
-namespace mls {
+namespace discord::dave::mls {
 
 struct QueuedProposal {
     ::mlspp::ValidatedContent content;
@@ -820,6 +818,4 @@ void Session::ClearPendingState()
     proposalQueue_.clear();
 }
 
-} // namespace mls
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave::mls

--- a/cpp/src/dave/mls/session.h
+++ b/cpp/src/dave/mls/session.h
@@ -26,9 +26,7 @@ struct SignaturePrivateKey;
 class State;
 } // namespace mlspp
 
-namespace discord {
-namespace dave {
-namespace mls {
+namespace discord::dave::mls {
 
 struct QueuedProposal;
 
@@ -134,6 +132,4 @@ private:
     MLSFailureCallback onMLSFailureCallback_{};
 };
 
-} // namespace mls
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave::mls

--- a/cpp/src/dave/mls/user_credential.cpp
+++ b/cpp/src/dave/mls/user_credential.cpp
@@ -4,9 +4,7 @@
 
 #include "dave/mls/util.h"
 
-namespace discord {
-namespace dave {
-namespace mls {
+namespace discord::dave::mls {
 
 ::mlspp::Credential CreateUserCredential(const std::string& userId,
                                          [[maybe_unused]] ProtocolVersion version)
@@ -32,6 +30,4 @@ std::string UserCredentialToString(const ::mlspp::Credential& cred,
     return std::to_string(uidVal);
 }
 
-} // namespace mls
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave::mls

--- a/cpp/src/dave/mls/user_credential.h
+++ b/cpp/src/dave/mls/user_credential.h
@@ -6,13 +6,9 @@
 
 #include "dave/version.h"
 
-namespace discord {
-namespace dave {
-namespace mls {
+namespace discord::dave::mls {
 
 ::mlspp::Credential CreateUserCredential(const std::string& userId, ProtocolVersion version);
 std::string UserCredentialToString(const ::mlspp::Credential& cred, ProtocolVersion version);
 
-} // namespace mls
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave::mls

--- a/cpp/src/dave/mls/util.cpp
+++ b/cpp/src/dave/mls/util.cpp
@@ -1,8 +1,6 @@
 #include "util.h"
 
-namespace discord {
-namespace dave {
-namespace mls {
+namespace discord::dave::mls {
 
 ::mlspp::bytes_ns::bytes BigEndianBytesFrom(uint64_t value) noexcept
 {
@@ -29,6 +27,4 @@ uint64_t FromBigEndianBytes(const ::mlspp::bytes_ns::bytes& buffer) noexcept
     return val;
 }
 
-} // namespace mls
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave::mls

--- a/cpp/src/dave/mls/util.h
+++ b/cpp/src/dave/mls/util.h
@@ -4,13 +4,9 @@
 
 #include <bytes/bytes.h>
 
-namespace discord {
-namespace dave {
-namespace mls {
+namespace discord::dave::mls {
 
 ::mlspp::bytes_ns::bytes BigEndianBytesFrom(uint64_t value) noexcept;
 uint64_t FromBigEndianBytes(const ::mlspp::bytes_ns::bytes& value) noexcept;
 
-} // namespace mls
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave::mls

--- a/cpp/src/dave/mls_key_ratchet.cpp
+++ b/cpp/src/dave/mls_key_ratchet.cpp
@@ -5,8 +5,7 @@
 #include "dave/common.h"
 #include "dave/logger.h"
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 MlsKeyRatchet::MlsKeyRatchet(::mlspp::CipherSuite suite, bytes baseSecret) noexcept
   : hashRatchet_(suite, std::move(baseSecret))
@@ -36,5 +35,4 @@ void MlsKeyRatchet::DeleteKey(KeyGeneration generation) noexcept
     hashRatchet_.erase(generation);
 }
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/mls_key_ratchet.h
+++ b/cpp/src/dave/mls_key_ratchet.h
@@ -5,8 +5,7 @@
 
 #include "dave_interfaces.h"
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 class MlsKeyRatchet : public IKeyRatchet {
 public:
@@ -22,5 +21,4 @@ private:
     ::mlspp::HashRatchet hashRatchet_;
 };
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/openssl_cryptor.cpp
+++ b/cpp/src/dave/openssl_cryptor.cpp
@@ -7,8 +7,7 @@
 #include "dave/common.h"
 #include "dave/logger.h"
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 void PrintSSLErrors()
 {
@@ -173,5 +172,4 @@ bool OpenSSLCryptor::Decrypt(ArrayView<uint8_t> plaintextBufferOut,
     return true;
 }
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/openssl_cryptor.h
+++ b/cpp/src/dave/openssl_cryptor.h
@@ -6,8 +6,7 @@
 
 #include "dave/cryptor.h"
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 class OpenSSLCryptor : public ICryptor {
 public:
@@ -32,5 +31,4 @@ private:
     EncryptionKey encryptionKey_;
 };
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/utils/clock.h
+++ b/cpp/src/dave/utils/clock.h
@@ -2,8 +2,7 @@
 
 #include <chrono>
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 class IClock {
 public:
@@ -20,5 +19,4 @@ public:
     TimePoint Now() const override { return BaseClock::now(); }
 };
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/utils/leb128.cpp
+++ b/cpp/src/dave/utils/leb128.cpp
@@ -4,8 +4,7 @@
 // The following code was copied from the webrtc source code:
 // https://webrtc.googlesource.com/src/+/refs/heads/main/modules/rtp_rtcp/source/leb128.cc
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 size_t Leb128Size(uint64_t value)
 {
@@ -56,5 +55,4 @@ size_t WriteLeb128(uint64_t value, uint8_t* buffer)
     return size;
 }
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/utils/leb128.h
+++ b/cpp/src/dave/utils/leb128.h
@@ -3,8 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 constexpr size_t Leb128MaxSize = 10;
 
@@ -19,5 +18,4 @@ uint64_t ReadLeb128(const uint8_t*& readAt, const uint8_t* end);
 // Leb128Size(value). Returns number of bytes consumed.
 size_t WriteLeb128(uint64_t value, uint8_t* buffer);
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/utils/scope_exit.h
+++ b/cpp/src/dave/utils/scope_exit.h
@@ -4,8 +4,7 @@
 #include <functional>
 #include <utility>
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 class [[nodiscard]] ScopeExit final {
 public:
@@ -44,5 +43,4 @@ private:
     std::function<void()> cleanup_;
 };
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/version.cpp
+++ b/cpp/src/dave/version.cpp
@@ -1,7 +1,6 @@
 #include "version.h"
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 constexpr ProtocolVersion CurrentDaveProtocolVersion = 1;
 
@@ -10,5 +9,4 @@ ProtocolVersion MaxSupportedProtocolVersion()
     return CurrentDaveProtocolVersion;
 }
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/src/dave/version.h
+++ b/cpp/src/dave/version.h
@@ -2,13 +2,11 @@
 
 #include <stdint.h>
 
-namespace discord {
-namespace dave {
+namespace discord::dave {
 
 using ProtocolVersion = uint16_t;
 using SignatureVersion = uint8_t;
 
 ProtocolVersion MaxSupportedProtocolVersion();
 
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave

--- a/cpp/test/codec_utils_tests.cpp
+++ b/cpp/test/codec_utils_tests.cpp
@@ -11,9 +11,7 @@
 #include "dave_test.h"
 #include "static_key_ratchet.h"
 
-namespace discord {
-namespace dave {
-namespace test {
+namespace discord::dave::test {
 
 TEST_F(DaveTests, RandomOpusFrame)
 {
@@ -375,6 +373,4 @@ TEST_F(DaveTests, H265TwoIdrSlice)
     EXPECT_EQ(unencryptedRanges[1].size, 6u);
 }
 
-} // namespace test
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave::test

--- a/cpp/test/cryptor_manager_tests.cpp
+++ b/cpp/test/cryptor_manager_tests.cpp
@@ -14,9 +14,7 @@
 using namespace testing;
 using namespace std::chrono_literals;
 
-namespace discord {
-namespace dave {
-namespace test {
+namespace discord::dave::test {
 
 // Gap can't be larger than the amount of bits allocated for it if we want to handle wraparound
 // correctly
@@ -194,6 +192,4 @@ TEST_F(DaveTests, CryptorManagerNoReprocess)
     EXPECT_TRUE(cryptorManager.CanProcessNonce(0, 11));
 }
 
-} // namespace test
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave::test

--- a/cpp/test/cryptor_tests.cpp
+++ b/cpp/test/cryptor_tests.cpp
@@ -10,9 +10,7 @@
 using namespace testing;
 using namespace std::chrono_literals;
 
-namespace discord {
-namespace dave {
-namespace test {
+namespace discord::dave::test {
 
 constexpr std::string_view RandomBytes =
   "0dc5aedd5bdc3f20be5697e54dd1f437b896a36f858c6f20bbd69e2a493ca170c4f0c1b9acd4"
@@ -145,6 +143,4 @@ TEST_F(DaveTests, RandomOpusFrameEncryptDecrypt)
     }
 }
 
-} // namespace test
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave::test

--- a/cpp/test/dave_test.cpp
+++ b/cpp/test/dave_test.cpp
@@ -1,8 +1,6 @@
 #include "dave_test.h"
 
-namespace discord {
-namespace dave {
-namespace test {
+namespace discord::dave::test {
 
 std::vector<uint8_t> GetBufferFromHex(const std::string_view& hex)
 {
@@ -22,6 +20,4 @@ std::vector<uint8_t> GetBufferFromHex(const std::string_view& hex)
     return buffer;
 }
 
-} // namespace test
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave::test

--- a/cpp/test/dave_test.h
+++ b/cpp/test/dave_test.h
@@ -3,9 +3,7 @@
 
 #include "dave/common.h"
 
-namespace discord {
-namespace dave {
-namespace test {
+namespace discord::dave::test {
 
 std::vector<uint8_t> GetBufferFromHex(const std::string_view& hex);
 
@@ -16,6 +14,4 @@ public:
     void TearDown() override {}
 };
 
-} // namespace test
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave::test

--- a/cpp/test/external_sender.cpp
+++ b/cpp/test/external_sender.cpp
@@ -3,9 +3,7 @@
 #include "dave/mls/parameters.h"
 #include "dave/mls/util.h"
 
-namespace discord {
-namespace dave {
-namespace test {
+namespace discord::dave::test {
 
 ExternalSender::ExternalSender(discord::dave::ProtocolVersion protocolVersion, uint64_t groupId)
 {
@@ -57,6 +55,4 @@ std::pair<std::vector<uint8_t>, std::vector<uint8_t>> ExternalSender::SplitCommi
     return std::make_pair(commitBytes, welcomeBytes);
 }
 
-} // namespace test
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave::test

--- a/cpp/test/external_sender.h
+++ b/cpp/test/external_sender.h
@@ -4,9 +4,7 @@
 
 #include "dave/version.h"
 
-namespace discord {
-namespace dave {
-namespace test {
+namespace discord::dave::test {
 
 class ExternalSender {
 public:
@@ -25,6 +23,4 @@ private:
     ::mlspp::ExternalSender externalSender_;
 };
 
-} // namespace test
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave::test

--- a/cpp/test/static_key_ratchet.cpp
+++ b/cpp/test/static_key_ratchet.cpp
@@ -7,9 +7,7 @@
 #include "dave/common.h"
 #include "dave/logger.h"
 
-namespace discord {
-namespace dave {
-namespace test {
+namespace discord::dave::test {
 
 EncryptionKey MakeStaticSenderKey(const std::string& userID)
 {
@@ -44,6 +42,4 @@ void StaticKeyRatchet::DeleteKey([[maybe_unused]] KeyGeneration generation) noex
     // noop
 }
 
-} // namespace test
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave::test

--- a/cpp/test/static_key_ratchet.h
+++ b/cpp/test/static_key_ratchet.h
@@ -4,9 +4,7 @@
 
 #include "dave_interfaces.h"
 
-namespace discord {
-namespace dave {
-namespace test {
+namespace discord::dave::test {
 
 EncryptionKey MakeStaticSenderKey(const std::string& userID);
 EncryptionKey MakeStaticSenderKey(uint64_t u64userID);
@@ -23,6 +21,4 @@ private:
     uint64_t u64userID_;
 };
 
-} // namespace test
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave::test

--- a/cpp/test/xssl_cryptor_tests.cpp
+++ b/cpp/test/xssl_cryptor_tests.cpp
@@ -11,9 +11,7 @@
 #include "dave_test.h"
 #include "static_key_ratchet.h"
 
-namespace discord {
-namespace dave {
-namespace test {
+namespace discord::dave::test {
 
 #ifdef WITH_BORINGSSL
 using CryptorVariant = BoringSSLCryptor;
@@ -159,6 +157,4 @@ TEST_F(DaveTests, XSSLNonceDiff)
     EXPECT_FALSE(memcmp(ciphertextBuffer1.data(), ciphertextBuffer2.data(), PLAINTEXT_SIZE) == 0);
 }
 
-} // namespace test
-} // namespace dave
-} // namespace discord
+} // namespace discord::dave::test


### PR DESCRIPTION
This pull request replaces the repeated namespace declarations with a [nested namespace declaration](https://en.cppreference.com/w/cpp/language/namespace.html), introduced in C++17 (which this library supports at minimum).

This is hopefully more concise and keeps code cleaner.